### PR TITLE
fix: remove multi-platform support from README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM archlinux/archlinux:latest
 
 # Build arguments for flexibility
 ARG ENTRYPOINT_SCRIPT=entrypoint.sh
-ARG TARGETARCH=amd64
 
 # Set environment for non-interactive installation
 ENV LANG=C.UTF-8
@@ -63,14 +62,8 @@ RUN bash -lc '\
 # Download and install VS Code directly from Microsoft
 USER root
 WORKDIR /tmp
-RUN case ${TARGETARCH} in \
-        amd64) ARCH=x64 ;; \
-        arm64) ARCH=arm64 ;; \
-        arm) ARCH=arm ;; \
-        *) ARCH=x64 ;; \
-    esac && \
-    mkdir -p /tmp/vscode && \
-    curl -L -o /tmp/vscode/vscode.tar.gz "https://update.code.visualstudio.com/latest/linux-${ARCH}/stable" && \
+RUN mkdir -p /tmp/vscode && \
+    curl -L -o /tmp/vscode/vscode.tar.gz "https://update.code.visualstudio.com/latest/linux-x64/stable" && \
     mkdir -p /opt/vscode && \
     tar -xzf /tmp/vscode/vscode.tar.gz -C /opt/vscode --strip-components=1 && \
     ln -sf /opt/vscode/bin/code /usr/local/bin/code && \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Arch Linux development environment with VS Code accessible via web browser (serv
 - Official Arch Linux base (`archlinux:latest`)
 - Microsoft VS Code direct download
 - Web interface at localhost:8080
-- Multi-platform (AMD64, ARM64, ARM32)
 - Configurable PUID/PGID for file permissions
 - AUR support via yay
 - Persistent volumes for config and home directory


### PR DESCRIPTION
This pull request simplifies the Docker setup for the Arch Linux development environment with VS Code by removing multi-architecture support and hardcoding the VS Code download to the x64 architecture. The documentation is updated to reflect this change.

**Dockerfile changes:**

* Removed the `TARGETARCH` build argument, eliminating the ability to select the architecture during build.
* Updated the VS Code installation step to always download the x64 version, removing logic for other architectures.

**Documentation update:**

* Removed the mention of multi-platform (AMD64, ARM64, ARM32) support from the feature list in `README.md`.