### PR TITLE
Feat/home config mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .github/SECRETS.md
 CLAUDE.md
 docs/todo.md
+home/
+test-home/

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,23 +72,20 @@ RUN mkdir -p /tmp/vscode && \
 # Switch back to root for system configuration
 USER root
 
-# Create workspace and config directories with subdirectories
-RUN mkdir -p /workspace /config/user-data /config/extensions /config/server-data /config/cli-data && \
-    chown -R developer:developer /workspace /config
+# Create workspace and prepare default developer config directories
+RUN mkdir -p /workspace /home/developer/.config /home/developer/.local/share && \
+    chown -R developer:developer /workspace /home/developer/.config /home/developer/.local/share
 
 # Set up environment variables
 ENV PUID=1000 \
     PGID=1000 \
     WORKSPACE_DIR=/workspace \
-    VSCODE_USER_DATA_DIR=/config/user-data \
-    VSCODE_EXTENSIONS_DIR=/config/extensions \
-    VSCODE_SERVER_DATA_DIR=/config/server-data \
+    VSCODE_DEFAULT_FOLDER=/workspace \
     VSCODE_HOST=0.0.0.0 \
     VSCODE_PORT=8080 \
     VSCODE_CONNECTION_TOKEN="" \
     VSCODE_SOCKET_PATH="" \
     VSCODE_ACCEPT_LICENSE=true \
-    VSCODE_CLI_DATA_DIR=/config/cli-data \
     VSCODE_VERBOSE=false \
     VSCODE_LOG_LEVEL=info \
     EXTRA_PACKAGES="" \
@@ -97,8 +94,8 @@ ENV PUID=1000 \
     SSL_CERT_DIR=/etc/ssl/certs \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-    XDG_CONFIG_HOME=/config \
-    XDG_DATA_HOME=/config
+    XDG_CONFIG_HOME=/home/developer/.config \
+    XDG_DATA_HOME=/home/developer/.local/share
 
 # Copy entrypoint script and auto-update script
 COPY scripts/${ENTRYPOINT_SCRIPT} /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ services:
 
 Commands: `docker-compose up -d` / `docker-compose down`
 
+Before starting the stack for the first time, create a directory on the host to hold the VS Code data:
+
+```bash
+mkdir -p ./config
+```
+
+You can swap `./config` for any other host path when you bind it to `/home/${USERNAME}/.config/arch-vscode`.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and customize. Key variables:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ services:
       - VSCODE_CONNECTION_TOKEN=${VSCODE_CONNECTION_TOKEN:-}
     volumes:
       - ./:/workspace
-      - ./config:/home/${USERNAME:-developer}/.config/arch-vscode
+      - ./home:/home/${USERNAME:-developer}
     ports:
       - "8080:8080"
     restart: unless-stopped
@@ -47,13 +47,13 @@ services:
 
 Commands: `docker-compose up -d` / `docker-compose down`
 
-Before starting the stack for the first time, create a directory on the host to hold the VS Code data:
+Before starting the stack for the first time, create a directory on the host to hold the VS Code data and home directory contents:
 
 ```bash
-mkdir -p ./config
+mkdir -p ./home
 ```
 
-`./config` is a host directory relative to the compose file. Swap it for any other path when binding to `/home/${USERNAME}/.config/arch-vscode` inside the container.
+`./home` is a host directory relative to the compose file. Swap it for any other path when binding to `/home/${USERNAME}` inside the container.
 
 ## Configuration
 
@@ -115,17 +115,17 @@ docker run -p 8080:8080 -e VSCODE_VERBOSE=true -e VSCODE_LOG_LEVEL=debug jjgroen
 
 ### Directory Structure
 ```
-$HOME/.config/arch-vscode/
-├── user-data/      # Settings, preferences, workspace state
-├── extensions/     # Installed extensions
-├── server-data/    # VS Code server runtime
-└── cli-data/       # CLI metadata
-
 /home/
-└── {username}/     # Shell history, configs, SSH keys, installed packages
+└── {username}/
+    ├── .config/arch-vscode/
+    │   ├── user-data/      # Settings, preferences, workspace state
+    │   ├── extensions/     # Installed extensions
+    │   ├── server-data/    # VS Code server runtime
+    │   └── cli-data/       # CLI metadata
+    └── ...                 # Shell history, SSH keys, caches, extra packages
 ```
 
-Bind-mount `./config` (or a directory of your choice) to `/home/${USERNAME}/.config/arch-vscode` to persist extensions, settings, and server state across container rebuilds.
+Bind-mount `./home` (or a directory of your choice) to `/home/${USERNAME}` to persist the VS Code data, shell history, and any other files you place in the home directory.
 
 ## Container Architecture
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Arch Linux development environment with VS Code accessible via web browser (serv
 - Web interface at localhost:8080
 - Configurable PUID/PGID for file permissions
 - AUR support via yay
-- Persistent volumes for config and home directory
+- Persistent VS Code data stored under the user home directory
 
 ## Quick Start
 
@@ -35,15 +35,10 @@ services:
       - PGID=${PGID:-1000}
     volumes:
       - ./:/workspace
-      - vscode-config:/config
-      - home-data:/home
+      - ./config:/home/${USERNAME:-developer}/.config/arch-vscode
     ports:
       - "8080:8080"
     restart: unless-stopped
-
-volumes:
-  vscode-config:
-  home-data:
 ```
 
 Commands: `docker-compose up -d` / `docker-compose down`
@@ -72,10 +67,11 @@ Copy `.env.example` to `.env` and customize. Key variables:
 - `TZ=UTC` - Timezone
 
 **Directories:**
-- `VSCODE_USER_DATA_DIR=/config/user-data`
-- `VSCODE_EXTENSIONS_DIR=/config/extensions`
-- `VSCODE_SERVER_DATA_DIR=/config/server-data`
-- `VSCODE_CLI_DATA_DIR=/config/cli-data`
+- `VSCODE_CONFIG_ROOT=$HOME/.config/arch-vscode`
+- `VSCODE_USER_DATA_DIR=$VSCODE_CONFIG_ROOT/user-data`
+- `VSCODE_EXTENSIONS_DIR=$VSCODE_CONFIG_ROOT/extensions`
+- `VSCODE_SERVER_DATA_DIR=$VSCODE_CONFIG_ROOT/server-data`
+- `VSCODE_CLI_DATA_DIR=$VSCODE_CONFIG_ROOT/cli-data`
 
 ## Usage Examples
 
@@ -104,7 +100,7 @@ docker run -p 8080:8080 -e VSCODE_VERBOSE=true -e VSCODE_LOG_LEVEL=debug jjgroen
 
 ### Directory Structure
 ```
-/config/
+$HOME/.config/arch-vscode/
 ├── user-data/      # Settings, preferences, workspace state
 ├── extensions/     # Installed extensions
 ├── server-data/    # VS Code server runtime
@@ -114,15 +110,14 @@ docker run -p 8080:8080 -e VSCODE_VERBOSE=true -e VSCODE_LOG_LEVEL=debug jjgroen
 └── {username}/     # Shell history, configs, SSH keys, installed packages
 ```
 
-Volumes persist extensions, settings, workspace state, installed packages, and user configs across container rebuilds.
+Bind-mount `./config` (or a directory of your choice) to `/home/${USERNAME}/.config/arch-vscode` to persist extensions, settings, and server state across container rebuilds.
 
 ## Container Architecture
 
 ```
 /
 ├── workspace/          # Project files (mount your directory here)
-├── home/{username}/    # Persistent user home
-├── config/             # VS Code data
+├── home/{username}/    # User home (+ VS Code data under .config/arch-vscode)
 └── usr/local/bin/
     └── entrypoint.sh   # Startup script
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ services:
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+      - USERNAME=${USERNAME:-developer}
+      - VSCODE_HOST=${VSCODE_HOST:-0.0.0.0}
+      - VSCODE_PORT=${VSCODE_PORT:-8080}
+      - VSCODE_CONNECTION_TOKEN=${VSCODE_CONNECTION_TOKEN:-}
     volumes:
       - ./:/workspace
       - ./config:/home/${USERNAME:-developer}/.config/arch-vscode
@@ -49,7 +53,7 @@ Before starting the stack for the first time, create a directory on the host to 
 mkdir -p ./config
 ```
 
-You can swap `./config` for any other host path when you bind it to `/home/${USERNAME}/.config/arch-vscode`.
+`./config` is a host directory relative to the compose file. Swap it for any other path when binding to `/home/${USERNAME}/.config/arch-vscode` inside the container.
 
 ## Configuration
 
@@ -66,11 +70,13 @@ Copy `.env.example` to `.env` and customize. Key variables:
 - `VSCODE_HOST=0.0.0.0` - Bind address
 - `VSCODE_PORT=8080` - Listen port
 - `VSCODE_CONNECTION_TOKEN=""` - Auth token (empty=no auth)
+- `VSCODE_SOCKET_PATH=""` - Optional UNIX socket
 - `VSCODE_VERBOSE=false` - Verbose logging
 - `VSCODE_LOG_LEVEL=info` - Log level (trace|debug|info|warn|error|critical|off)
+- `VSCODE_ACCEPT_LICENSE=true` - Auto-accept server license terms
 
 **System:**
-- `EXTRA_PACKAGES=""` - Space-separated packages to install
+- `EXTRA_PACKAGES=""` - Space-separated packages to install at startup
 - `AUTO_UPDATE=false` - Enable auto-updates
 - `TZ=UTC` - Timezone
 
@@ -80,6 +86,7 @@ Copy `.env.example` to `.env` and customize. Key variables:
 - `VSCODE_EXTENSIONS_DIR=$VSCODE_CONFIG_ROOT/extensions`
 - `VSCODE_SERVER_DATA_DIR=$VSCODE_CONFIG_ROOT/server-data`
 - `VSCODE_CLI_DATA_DIR=$VSCODE_CONFIG_ROOT/cli-data`
+- These values default to the paths above when unset; override any of them if you need a different layout.
 
 ## Usage Examples
 
@@ -134,9 +141,9 @@ Container starts as root, entrypoint switches to configured user. UID/GID mappin
 
 ## Features Detail
 
-**SSH Agent:** Automatically started on boot. SSH_AUTH_SOCK available for git operations.
+**SSH Agent:** Entrypoint starts `ssh-agent` when one is not already running so `SSH_AUTH_SOCK` is available for git operations.
 
-**Package Installation:** Use pacman/yay as normal. Packages persist in home volume. EXTRA_PACKAGES auto-installs on start.
+**Package Installation:** Runtime pacman/yay installs modify the container filesystem and are lost when the container is rebuilt. Use `EXTRA_PACKAGES` (reinstalled on each start) or bake dependencies into a custom image for persistence.
 
 **Custom Username:** Set USERNAME env var. Default is "developer". Home persists regardless of username.
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,7 +12,7 @@ services:
       - TZ=UTC
     volumes:
       - ./test-workspace:/workspace
-      - ./test-config:/home/usert/.config/arch-vscode
+      - ./test-home:/home/usert
     ports:
       - "9999:8080"
     restart: "no"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,14 +12,9 @@ services:
       - TZ=UTC
     volumes:
       - ./test-workspace:/workspace
-      - test-config:/config
-      - test-home:/home
+      - ./test-config:/home/usert/.config/arch-vscode
     ports:
       - "9999:8080"
     restart: "no"
     stdin_open: true
     tty: true
-
-volumes:
-  test-config:
-  test-home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,12 @@ services:
       - USERNAME=${USERNAME:-developer}
       - WORKSPACE_DIR=/workspace
       - VSCODE_DEFAULT_FOLDER=${VSCODE_DEFAULT_FOLDER:-/workspace}
-      - VSCODE_USER_DATA_DIR=/config/user-data
-      - VSCODE_EXTENSIONS_DIR=/config/extensions
-      - VSCODE_SERVER_DATA_DIR=/config/server-data
       - EXTRA_PACKAGES=${EXTRA_PACKAGES:-}
       - AUTO_UPDATE=${AUTO_UPDATE:-false}
       - TZ=${TZ:-UTC}
     volumes:
       - ./:/workspace
-      - vscode-config:/config
-      - home-data:/home
+      - ./config:/home/${USERNAME:-developer}/.config/arch-vscode
     ports:
       - "8080:8080"
     restart: unless-stopped
@@ -31,9 +27,3 @@ services:
       retries: 3
     networks:
       - arch-vscode-net
-
-volumes:
-  vscode-config:
-    driver: local
-  home-data:
-    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TZ=${TZ:-UTC}
     volumes:
       - ./:/workspace
-      - ./config:/home/${USERNAME:-developer}/.config/arch-vscode
+      - ./home:/home/${USERNAME:-developer}
     ports:
       - "8080:8080"
     restart: unless-stopped

--- a/scripts/ci-smoke-test.sh
+++ b/scripts/ci-smoke-test.sh
@@ -10,6 +10,8 @@ compose() {
   docker compose -f "$COMPOSE_FILE" "$@"
 }
 
+mkdir -p test-workspace test-home
+
 FAILED=0
 trap 'FAILED=1' ERR
 cleanup() {


### PR DESCRIPTION
This pull request refactors the way persistent VS Code configuration and data are stored and mounted in the container environment. Instead of using a separate `/config` directory and Docker volumes, all VS Code data is now stored under the user's home directory (e.g., `/home/developer/.config/arch-vscode`). The changes affect the Dockerfile, docker-compose files, entrypoint script, and documentation, resulting in a simpler and more portable setup that is easier to manage and customize.

**Container filesystem and environment changes:**

* All VS Code configuration and data directories are now created under `/home/developer/.config/arch-vscode` and `/home/developer/.local/share`, replacing the previous `/config` structure. Environment variables such as `XDG_CONFIG_HOME` and `XDG_DATA_HOME` are set accordingly. (`Dockerfile`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L75-L91) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L100-R98)
* Docker Compose files (`docker-compose.yml`, `docker-compose.test.yml`) now bind-mount a host `./home` directory directly to `/home/{username}` in the container, eliminating the need for named volumes for config and home data. (`docker-compose.yml`, [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L11-R16) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L34-L39); `docker-compose.test.yml`, [[3]](diffhunk://#diff-f4824493351fb6e294d8fcc9cd83a3d4536b8b0539a0c957afc94fa18a45ab3aL15-L25)

**Entrypoint and runtime configuration:**

* The entrypoint script now dynamically configures all VS Code paths under the user's home and ensures the required directories exist at startup. It no longer references `/config` and sets up environment variables for all VS Code data locations. (`scripts/entrypoint.sh`, [[1]](diffhunk://#diff-913fb747600da65f297c9fe6e47a424f47ac65e051960d33be397e4153929241L42-R42) [[2]](diffhunk://#diff-913fb747600da65f297c9fe6e47a424f47ac65e051960d33be397e4153929241L90-R136) [[3]](diffhunk://#diff-913fb747600da65f297c9fe6e47a424f47ac65e051960d33be397e4153929241L128-R160)
* The CI smoke test script creates the necessary test workspace and home directories for bind-mounting. (`scripts/ci-smoke-test.sh`, [scripts/ci-smoke-test.shR13-R14](diffhunk://#diff-5c5e41d5659753c6d5e0ecde01fa7ffad1d4f4d0e1e31d58fc6243f1e0c2b014R13-R14))

**Documentation updates:**

* The README is updated to reflect the new directory layout, environment variables, and bind-mount instructions. It clarifies that VS Code data is now stored under the user's home directory and describes how to override paths if needed. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R57) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R89) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R135) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R146)